### PR TITLE
feat: 카테고리별 소득/지출 통계 API 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,32 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/myteam/household_book/dto/CategoryStatsDto.java
+++ b/src/main/java/com/myteam/household_book/dto/CategoryStatsDto.java
@@ -1,0 +1,15 @@
+package com.myteam.household_book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CategoryStatsDto {
+    private Integer categoryId;
+    private String categoryName;
+    private Long totalAmount;
+    private Double percentage;
+}

--- a/src/main/java/com/myteam/household_book/dto/StatsSummaryDto.java
+++ b/src/main/java/com/myteam/household_book/dto/StatsSummaryDto.java
@@ -1,0 +1,18 @@
+package com.myteam.household_book.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class StatsSummaryDto {
+    private List<CategoryStatsDto> incomeStats;
+    private List<CategoryStatsDto> usageStats;
+    private Long totalIncome;
+    private Long totalUsage;
+    private Long netAmount;
+}

--- a/src/main/java/com/myteam/household_book/repository/IncomeRepository.java
+++ b/src/main/java/com/myteam/household_book/repository/IncomeRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository; //JpaRepository는
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 // JpaRepository를 상속받아 CRUD 작업을 자동으로 수행
@@ -23,4 +24,48 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
             @Param("userId") Long userId,
             @Param("keyword") String keyword
     );
+
+    // 카테고리별 소득 통계 (날짜 범위)
+    @Query("SELECT i.incomeCategory as categoryId, SUM(i.incomePrice) as totalAmount " +
+            "FROM Income i " +
+            "WHERE i.userId.userId = :userId " +
+            "AND i.incomeDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY i.incomeCategory " +
+            "ORDER BY SUM(i.incomePrice) DESC")
+    List<Object[]> findIncomeStatsByCategory(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
+
+    // 월별 카테고리 통계 (기존 년/월 방식 활용)
+    @Query("SELECT i.incomeCategory as categoryId, SUM(i.incomePrice) as totalAmount " +
+            "FROM Income i " +
+            "WHERE i.userId.userId = :userId " +
+            "AND FUNCTION('YEAR', i.incomeDate) = :year " +
+            "AND FUNCTION('MONTH', i.incomeDate) = :month " +
+            "GROUP BY i.incomeCategory " +
+            "ORDER BY SUM(i.incomePrice) DESC")
+    List<Object[]> findIncomeStatsByCategoryForMonth(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month);
+
+    // 총 소득 계산 (날짜 범위)
+    @Query("SELECT SUM(i.incomePrice) FROM Income i " +
+            "WHERE i.userId.userId = :userId " +
+            "AND i.incomeDate BETWEEN :startDate AND :endDate")
+    Long findTotalIncomeByUserAndDateRange(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
+
+    // 월별 총 소득 (기존 방식 활용)
+    @Query("SELECT SUM(i.incomePrice) FROM Income i " +
+            "WHERE i.userId.userId = :userId " +
+            "AND FUNCTION('YEAR', i.incomeDate) = :year " +
+            "AND FUNCTION('MONTH', i.incomeDate) = :month")
+    Long findTotalIncomeByUserAndMonth(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month);
 }

--- a/src/main/java/com/myteam/household_book/repository/UsageRepository.java
+++ b/src/main/java/com/myteam/household_book/repository/UsageRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 // JpaRepository를 상속받아 CRUD 작업을 자동으로 수행
@@ -23,4 +24,48 @@ public interface UsageRepository extends JpaRepository<Usage, Long> {
             @Param("userId") Long userId,
             @Param("keyword") String keyword
     );
+
+    // 월별 카테고리 통계
+    @Query("SELECT u.usageCategory as categoryId, SUM(u.usagePrice) as totalAmount " +
+            "FROM Usage u " +
+            "WHERE u.userId.userId = :userId " +
+            "AND FUNCTION('YEAR', u.usageDate) = :year " +
+            "AND FUNCTION('MONTH', u.usageDate) = :month " +
+            "GROUP BY u.usageCategory " +
+            "ORDER BY SUM(u.usagePrice) DESC")
+    List<Object[]> findUsageStatsByCategoryForMonth(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month);
+
+    // 날짜 범위 카테고리 통계
+    @Query("SELECT u.usageCategory as categoryId, SUM(u.usagePrice) as totalAmount " +
+            "FROM Usage u " +
+            "WHERE u.userId.userId = :userId " +
+            "AND u.usageDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY u.usageCategory " +
+            "ORDER BY SUM(u.usagePrice) DESC")
+    List<Object[]> findUsageStatsByCategory(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
+
+    // 월별 총 지출
+    @Query("SELECT SUM(u.usagePrice) FROM Usage u " +
+            "WHERE u.userId.userId = :userId " +
+            "AND FUNCTION('YEAR', u.usageDate) = :year " +
+            "AND FUNCTION('MONTH', u.usageDate) = :month")
+    Long findTotalUsageByUserAndMonth(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month);
+
+    // 날짜 범위 총 지출
+    @Query("SELECT SUM(u.usagePrice) FROM Usage u " +
+            "WHERE u.userId.userId = :userId " +
+            "AND u.usageDate BETWEEN :startDate AND :endDate")
+    Long findTotalUsageByUserAndDateRange(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/myteam/household_book/transaction/TransactionStatisticsController.java
+++ b/src/main/java/com/myteam/household_book/transaction/TransactionStatisticsController.java
@@ -1,0 +1,37 @@
+package com.myteam.household_book.transaction;
+
+import com.myteam.household_book.dto.StatsSummaryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/transaction/statistics")
+@RequiredArgsConstructor  // 생성자 주입
+public class TransactionStatisticsController {
+
+    private final TransactionStatisticsService transactionStatisticsService;
+
+    @GetMapping("/monthly/{userId}")
+    public ResponseEntity<StatsSummaryDto> getMonthlyStats(
+            @PathVariable Long userId,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        StatsSummaryDto summary = transactionStatisticsService.getMonthlyIncomeStatistics(userId, year, month);
+        return ResponseEntity.ok(summary);
+    }
+
+    @GetMapping("/range/{userId}")
+    public ResponseEntity<StatsSummaryDto> getRangeStats(
+            @PathVariable Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+
+        StatsSummaryDto summary = transactionStatisticsService.getIncomeStatistics(userId, startDate, endDate);
+        return ResponseEntity.ok(summary);
+    }
+}

--- a/src/main/java/com/myteam/household_book/transaction/TransactionStatisticsService.java
+++ b/src/main/java/com/myteam/household_book/transaction/TransactionStatisticsService.java
@@ -1,0 +1,99 @@
+package com.myteam.household_book.transaction;
+
+import com.myteam.household_book.dto.CategoryStatsDto;
+import com.myteam.household_book.dto.StatsSummaryDto;
+import com.myteam.household_book.entity.Category;
+import com.myteam.household_book.repository.CategoryRepository;
+import com.myteam.household_book.repository.IncomeRepository;
+import com.myteam.household_book.repository.UsageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor  // 생성자 주입으로 변경
+public class TransactionStatisticsService {
+
+    private final IncomeRepository incomeRepository;
+    private final UsageRepository usageRepository;
+    private final CategoryRepository categoryRepository;
+
+    // 월별 통계 (Income만 사용하는 버전)
+    @Transactional(readOnly = true)
+    public StatsSummaryDto getMonthlyIncomeStatistics(Long userId, int year, int month) {
+
+        // 카테고리 정보 조회 - Integer 타입으로 변환
+        List<Category> categories = categoryRepository.findAll();
+        Map<Integer, String> categoryMap = categories.stream()
+                .collect(Collectors.toMap(
+                        category -> category.getCategoryId().intValue(), // Long을 Integer로 변환
+                        Category::getCategoryName));
+
+        // 소득 통계만 조회
+        List<Object[]> incomeRawStats = incomeRepository.findIncomeStatsByCategoryForMonth(userId, year, month);
+        Long totalIncome = incomeRepository.findTotalIncomeByUserAndMonth(userId, year, month);
+        if (totalIncome == null) totalIncome = 0L;
+
+        // 지출은 일단 빈 리스트로 처리 (UsageRepository 메서드가 없으므로)
+        List<CategoryStatsDto> usageStats = new ArrayList<>();
+        Long totalUsage = 0L;
+
+        // 소득 통계 변환
+        List<CategoryStatsDto> incomeStats = convertToStatsDto(incomeRawStats, categoryMap, totalIncome);
+
+        Long netAmount = totalIncome - totalUsage;
+
+        return new StatsSummaryDto(incomeStats, usageStats, totalIncome, totalUsage, netAmount);
+    }
+
+    // 날짜 범위 통계 (Income만 사용하는 버전)
+    @Transactional(readOnly = true)
+    public StatsSummaryDto getIncomeStatistics(Long userId,
+                                               LocalDateTime startDate,
+                                               LocalDateTime endDate) {
+
+        List<Category> categories = categoryRepository.findAll();
+        Map<Integer, String> categoryMap = categories.stream()
+                .collect(Collectors.toMap(
+                        category -> category.getCategoryId().intValue(),
+                        Category::getCategoryName));
+
+        List<Object[]> incomeRawStats = incomeRepository.findIncomeStatsByCategory(userId, startDate, endDate);
+        Long totalIncome = incomeRepository.findTotalIncomeByUserAndDateRange(userId, startDate, endDate);
+        if (totalIncome == null) totalIncome = 0L;
+
+        // 지출은 일단 빈 리스트로 처리
+        List<CategoryStatsDto> usageStats = new ArrayList<>();
+        Long totalUsage = 0L;
+
+        List<CategoryStatsDto> incomeStats = convertToStatsDto(incomeRawStats, categoryMap, totalIncome);
+
+        Long netAmount = totalIncome - totalUsage;
+
+        return new StatsSummaryDto(incomeStats, usageStats, totalIncome, totalUsage, netAmount);
+    }
+
+    private List<CategoryStatsDto> convertToStatsDto(List<Object[]> rawStats,
+                                                     Map<Integer, String> categoryMap,
+                                                     Long total) {
+        List<CategoryStatsDto> result = new ArrayList<>();
+
+        for (Object[] row : rawStats) {
+            Integer categoryId = (Integer) row[0];
+            Long amount = (Long) row[1];
+            String categoryName = categoryMap.getOrDefault(categoryId, "Unknown");
+            Double percentage = total > 0 ? (amount.doubleValue() / total.doubleValue() * 100) : 0.0;
+
+            result.add(new CategoryStatsDto(categoryId, categoryName, amount, percentage));
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
- 소득/지출 카테고리별 금액 집계 및 비율 계산 기능 추가
- 월별 통계 조회 API 엔드포인트 구현 (/api/transaction/statistics/monthly/{userId})
- 날짜 범위별 통계 조회 API 엔드포인트 구현 (/api/transaction/statistics/range/{userId})
- 기존 IncomeRepository, UsageRepository에 통계용 쿼리 메서드 추가
- CategoryStatsDto, StatsSummaryDto 응답 객체 생성
- TransactionStatisticsService, TransactionStatisticsController 추가

API 응답 포함 데이터:
- 카테고리별 총액 및 비율
- 총 소득/지출 금액
- 순수익 계산
- 프론트엔드 차트 연동 가능한 구조"