### PR TITLE
feat: 카카오 소셜 로그인 및 JWT 인증 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,29 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId> <!-- gson을 쓰는 경우 jjwt-gson으로 바꿔도 됨 -->
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
 
 	</dependencies>
 

--- a/src/main/java/com/myteam/household_book/config/AppConfig.java
+++ b/src/main/java/com/myteam/household_book/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.myteam.household_book.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/myteam/household_book/config/SecurityConfig.java
+++ b/src/main/java/com/myteam/household_book/config/SecurityConfig.java
@@ -1,46 +1,35 @@
 package com.myteam.household_book.config;
-/*
+
+import com.myteam.household_book.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.config.Customizer;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public UserDetailsService userDetailsService() {
-        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
-        manager.createUser(org.springframework.security.core.userdetails.User
-                .withUsername("a")
-                .password(passwordEncoder().encode("1234"))
-                .roles("USER")
-                .build());
-        return manager;
-    }
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화
-                .authorizeHttpRequests(auth -> {
-                    auth
-                            .anyRequest().authenticated();  // 모든 요청에 인증 필요
-                })
-                .httpBasic(Customizer.withDefaults());  // HTTP Basic 인증 활성화
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",    // 로그인 관련은 인증 없이
+                                "/error",      // 에러 페이지
+                                "/favicon.ico"
+                        ).permitAll()
+                        .anyRequest().authenticated()  // 그 외엔 인증 필요
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 }
-*/

--- a/src/main/java/com/myteam/household_book/entity/User.java
+++ b/src/main/java/com/myteam/household_book/entity/User.java
@@ -18,6 +18,9 @@ public class User {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "kakao_id", unique = true)
+    private Long kakaoId;
+
     @Column(nullable = false)
     private String username;
 

--- a/src/main/java/com/myteam/household_book/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/myteam/household_book/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.myteam.household_book.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. Authorization 헤더에서 JWT 추출
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7); // "Bearer " 이후부터 자름
+
+            // 2. 토큰 유효성 검증
+            if (jwtUtil.validateToken(token)) {
+                // 3. 사용자 이메일 추출
+                String email = jwtUtil.extractEmail(token);
+
+                // 4. 인증 객체 생성
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(email, null, null);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                // 5. SecurityContext에 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        // 다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/myteam/household_book/jwt/JwtUtil.java
+++ b/src/main/java/com/myteam/household_book/jwt/JwtUtil.java
@@ -1,0 +1,70 @@
+package com.myteam.household_book.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+// 현재는 비밀키를 JwtUtil 내에서 임시로 생성하고 있음. 추후 application.properties에 키를 넣어서 관리하는 게 좋음.
+
+@Component
+public class JwtUtil {
+
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private final long EXPIRATION_TIME = 1000 * 60 * 60 * 24; // 24시간
+
+    private Key getSigningKey() {
+        byte[] keyBytes = "mysecretkeymysecretkeymysecretkeymysecretkey".getBytes(); // 256비트 이상
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+
+    // JWT 토큰 생성
+    public String generateToken(String nickname) {
+        return Jwts.builder()
+                .setSubject(nickname)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(key)
+                .compact();
+    }
+
+
+    // JWT 토큰에서 이메일 추출
+    public String validateAndGetEmail(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (JwtException e) {
+            throw new RuntimeException("JWT 유효성 검증 실패: " + e.getMessage());
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);  // 예외 발생 없으면 유효
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String extractEmail(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.getSubject();  // 일반적으로 이메일이 subject에 저장됨
+    }
+}

--- a/src/main/java/com/myteam/household_book/login/KakaoAuthController.java
+++ b/src/main/java/com/myteam/household_book/login/KakaoAuthController.java
@@ -1,5 +1,6 @@
 package com.myteam.household_book.login;
 
+import com.myteam.household_book.jwt.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,20 +28,24 @@ public class KakaoAuthController {
     }
 
     private final KakaoAuthService kakaoAuthService;
+    private final JwtUtil jwtUtil;
 
     @Autowired
-    public KakaoAuthController(KakaoAuthService kakaoAuthService) {
+    public KakaoAuthController(KakaoAuthService kakaoAuthService, JwtUtil jwtUtil) {
         this.kakaoAuthService = kakaoAuthService;
+        this.jwtUtil = jwtUtil;
     }
+
 
     @GetMapping("/callback")
     public ResponseEntity<?> kakaoCallback(@RequestParam("code") String code) {
-        // 1. 카카오에서 Access Token 받기
         String accessToken = kakaoAuthService.getKakaoAccessToken(code);
-
-        // 2. Access Token을 이용해 사용자 정보 가져오기
-        Map<String, Object> userInfo = kakaoAuthService.getUserInfo(accessToken);
-
-        return ResponseEntity.ok(userInfo);
+        String nickname = kakaoAuthService.getKakaoUserNickname(accessToken);
+        String jwt = jwtUtil.generateToken(nickname);
+        return ResponseEntity.ok(jwt);
     }
+
+
+
+
 }

--- a/src/main/java/com/myteam/household_book/login/KakaoAuthService.java
+++ b/src/main/java/com/myteam/household_book/login/KakaoAuthService.java
@@ -1,20 +1,31 @@
 package com.myteam.household_book.login;
 
+import com.myteam.household_book.entity.User;
+import com.myteam.household_book.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class KakaoAuthService {
 
-    private static final String CLIENT_ID = "노션참고";
-    private static final String CLIENT_SECRET = "노션참고";
+    private static final String CLIENT_ID = "//노션참고";
+    private static final String CLIENT_SECRET = "//노션참고";
     private static final String REDIRECT_URI = "http://localhost:2705/auth/kakao/callback";
     private static final String TOKEN_REQUEST_URL = "https://kauth.kakao.com/oauth/token";
+    private final RestTemplate restTemplate;
+
+    public KakaoAuthService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
 
     public String getKakaoAccessToken(String code) {
         RestTemplate restTemplate = new RestTemplate();
@@ -60,6 +71,58 @@ public class KakaoAuthService {
 
         return response.getBody();
     }
+
+    public String getKakaoUserNickname(String accessToken) {
+        String url = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        Map<String, Object> body = response.getBody();
+        Map<String, Object> properties = (Map<String, Object>) body.get("properties");
+
+        return (String) properties.get("nickname");
+    }
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public String handleKakaoUser(String accessToken) {
+        Map<String, Object> body = getUserInfo(accessToken);
+        Long kakaoId = ((Number) body.get("id")).longValue();
+
+        Map<String, Object> properties = (Map<String, Object>) body.get("properties");
+        String nickname = (String) properties.get("nickname");
+        String profileImage = (String) properties.get("profile_image");
+
+        Optional<User> existingUser = userRepository.findByKakaoId(kakaoId);
+
+        if (existingUser.isEmpty()) {
+            User newUser = new User();
+            newUser.setKakaoId(kakaoId);  // 이 필드는 User 엔티티에 추가되어야 함
+            newUser.setUsername(nickname);
+            newUser.setEmail("kakao_" + kakaoId + "@example.com");
+            newUser.setProfileImage(profileImage);
+            newUser.setPassword("kakao-login");
+            newUser.setUserBirthDate(LocalDate.of(2000, 1, 1));
+            newUser.setGender(User.Gender.O);
+            newUser.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+            newUser.setStatus((byte) 1);
+
+            userRepository.save(newUser);
+        }
+
+        return nickname; // JWT 발급 시 사용
+    }
+
 
 }
 

--- a/src/main/java/com/myteam/household_book/repository/UserRepository.java
+++ b/src/main/java/com/myteam/household_book/repository/UserRepository.java
@@ -6,6 +6,12 @@ import com.myteam.household_book.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByKakaoId(Long kakaoId);
+
+
 }


### PR DESCRIPTION
- 카카오 OAuth2.0 연동하여 로그인/회원가입 처리
- 카카오 닉네임 기반으로 JWT 토큰 발급
// 카카오 개발자 설정에서 아직 이메일 받아올 권한이 없음. 그래서 닉네임, kakaouserid 기준으로 개발
- 기존 User 엔티티와 연동하여 사용자 정보 저장
- JWT 인증 필터 적용으로 보호된 API 접근 가능
- RestTemplate 및 AppConfig 설정 추가