### PR TITLE
feat: 게스트 모드 로그인 기능 추가

### DIFF
--- a/src/main/java/com/myteam/household_book/controller/GuestLoginController.java
+++ b/src/main/java/com/myteam/household_book/controller/GuestLoginController.java
@@ -1,0 +1,50 @@
+package com.myteam.household_book.controller;
+
+import com.myteam.household_book.entity.User;
+import com.myteam.household_book.jwt.JwtUtil;
+import com.myteam.household_book.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/auth/guest")
+@RequiredArgsConstructor
+public class GuestLoginController {
+
+    private final
+    UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> guestLogin() {
+        // 랜덤 닉네임 생성 (예: Guest_8391)
+        String nickname = "Guest_" + UUID.randomUUID().toString().substring(0, 8);
+
+        // DB에 사용자 저장 (이메일, 비밀번호, 생년월일 등 없이)
+        User user = new User();
+        user.setUsername(nickname);
+        user.setPassword("guest-login");
+        user.setGender(User.Gender.O);
+        user.setAlarmEnabled(false);
+        user.setStatus((byte) 1);
+        user.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
+        user.setUserBirthDate(LocalDate.of(2000, 1, 1));
+
+
+        userRepository.save(user);
+
+        // JWT 발급 (닉네임 기준)
+        String token = jwtUtil.generateToken(nickname);
+
+        return ResponseEntity.ok(Map.of("token", token, "nickname", nickname));
+    }
+}

--- a/src/main/java/com/myteam/household_book/entity/User.java
+++ b/src/main/java/com/myteam/household_book/entity/User.java
@@ -36,8 +36,8 @@ public class User {
 
     private Byte status;
 
-    @Column(nullable = false, unique = true, length = 255)
-    private String email;
+    @Column(nullable = true, unique = true, length = 255)
+    private String email; // 회원만 이메일 가짐, 비회원은 null
 
     @Column(nullable = false, length = 255)
     private String password;


### PR DESCRIPTION
- /auth/guest/login 엔드포인트 구현
- 회원가입 없이 임시 사용자 계정 생성 및 JWT 발급
- 기존 User 엔티티 구조에 맞춰 기본값 자동 세팅
- 게스트 유저도 일반 로그인 유저와 동일하게 인증 기능 사용 가능